### PR TITLE
feat: improve hooks, snapshot reuse, and verify tool guidance (v0.0.7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,6 @@ jobs:
             https://www.npmjs.com/package/openqa/v/${{ steps.package_version.outputs.version }}
 
             ### Documentation
-            See [README.md](https://github.com/auto-browse/openqa#readme) for usage instructions.
+            See [README.md](https://github.com/openqa-labs/openqa#readme) for usage instructions.
           draft: false
           prerelease: false

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -6,7 +6,7 @@
    ```bash
    npm search openqa
    ```
-   If "openqa" is taken, you'll need to use a scoped name like `@auto-browse/openqa`
+   If "openqa" is taken, you'll need to use a scoped name like `@openqa-labs/openqa`
 
 2. **Login to npm:**
    ```bash
@@ -126,5 +126,5 @@ When releasing new versions:
 
 After publishing, verify:
 - npm package: https://www.npmjs.com/package/openqa
-- GitHub release: https://github.com/auto-browse/openqa/releases
+- GitHub release: https://github.com/openqa-labs/openqa/releases
 - Installation works: `npm install openqa` in a test project

--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ Resets the Claude Code conversation session for a specific browser context. Usef
 
 ## Links
 
-- **Website:** https://www.auto-browse.com/
+- **Website:** https://openqa.io/
 - **NPM:** https://www.npmjs.com/package/openqa
-- **GitHub:** https://github.com/auto-browse/openqa
+- **GitHub:** https://github.com/openqa-labs/openqa
 
 ## License
 

--- a/examples/playwright-yaml/README.md
+++ b/examples/playwright-yaml/README.md
@@ -113,5 +113,5 @@ cp .env.example .env
 
 ## Learn More
 
-- [OpenQA Documentation](https://github.com/auto-browse/openqa)
+- [OpenQA Documentation](https://openqa.io/)
 - [Playwright Documentation](https://playwright.dev)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openqa",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Agent Harness for Browser Test Automation — write tests in natural language, powered by Claude Code",
   "type": "module",
   "bin": {

--- a/src/agent/Orchestrator.js
+++ b/src/agent/Orchestrator.js
@@ -180,7 +180,6 @@ socket.on('error', () => process.exit(1));
             let stepCount = 0;
             const fullOutput = [];
             let currentSessionId = existingSessionId;
-            let lastToolName = '';
             let assertionFailed = false;
             let assertionError = '';
 
@@ -222,11 +221,10 @@ socket.on('error', () => process.exit(1));
                                 if (this.verbose) this.logger.log(`💬 Assistant: ${event.text}`);
                             } else if (event.type === 'tool_call') {
                                 stepCount++;
-                                lastToolName = event.name || '';
                                 if (this.verbose) this.logger.log(`🔧 Tool Call: ${event.name}(${event.args})`);
                             } else if (event.type === 'tool_error') {
                                 if (this.verbose) this.logger.log(`❌ Tool Error: ${event.error}`);
-                                if (lastToolName.includes('browser_verify_')) {
+                                if (event.toolName?.includes('browser_verify_')) {
                                     // Assertion tool failed — flag it but do NOT kill the subprocess.
                                     // The PostToolUseFailure hook blocks further tool calls and instructs
                                     // Claude to write a failure summary before stopping gracefully.

--- a/src/agent/Orchestrator.js
+++ b/src/agent/Orchestrator.js
@@ -38,12 +38,65 @@ export class Orchestrator {
         const systemPrompt = `You are a Playwright Test Agent. CRITICAL RULES:
 1. You MUST call at least one Playwright MCP tool for EVERY user instruction.
 2. NEVER respond based on cached or remembered page state — always interact with the live browser.
-3. For ACTION steps (navigate, click, type, scroll, select): use the corresponding browser_* action tool.
-   - If an action tool returns an error, TRY AGAIN using a different approach (different selector, browser_snapshot to re-read the DOM, etc.).
-4. For VERIFICATION/ASSERTION steps ("should see", "verify", "check", "assert", "confirm", "visible"):
-   - You MUST call one of: browser_verify_text_visible, browser_verify_element_visible, browser_verify_list_visible, or browser_verify_value.
-   - Do NOT describe what you see — call the assertion tool.
-   - If an assertion tool returns an error, the test step has DEFINITIVELY FAILED. Report the failure clearly and do not retry.
+3. For ACTION steps (navigate, click, type, scroll, select, hover, drag):
+   You need element refs from a snapshot before interacting with any element.
+   Each action tool response automatically includes a snapshot of the resulting page state.
+   REUSE THAT SNAPSHOT — if the most recent tool output contains a [Snapshot](path/to/file.yml)
+   link, read that file to get current element refs. Only call browser_snapshot explicitly when
+   no recent snapshot file is available.
+   Each interactive element in the snapshot YAML has a [ref=eXX] tag:
+     Example snapshot line:  textbox "What needs to be done?" [ref=e10]
+     Example snapshot line:  checkbox "Toggle Todo" [ref=e42]
+     Example snapshot line:  link "Active" [ref=f1e7]   ← inside an iframe: prefix "f1"
+   Use ONLY the bare ref (e.g. "e10", "f1e7") as the "target" parameter in the action tool.
+   NEVER use the accessible name, role text, or any CSS selector you construct as "target".
+   If an action tool returns an error after using the correct ref, read the new snapshot file
+   from that action's output (page may have changed) and retry with the updated ref.
+4. For VERIFICATION/ASSERTION steps ("should see", "verify", "check", "assert", "confirm", "visible", "equal", "contains", "count"):
+   ALWAYS try built-in verify tools first — they handle most assertions without custom code:
+   - browser_verify_text_visible    → text is visible anywhere on the page
+   - browser_verify_element_visible → an element with a specific role/name is visible
+   - browser_verify_list_visible    → a list contains specific named items
+   - browser_verify_value           → an input element's value matches expected
+
+   For COUNT assertions ("should see N items"): use browser_verify_list_visible with the
+   actual item names rather than writing DOM query code. If you don't yet know the item
+   names, read the latest snapshot file first to discover them, then call
+   browser_verify_list_visible with those exact names.
+
+   ONLY use browser_evaluate when the built-in tools genuinely cannot express the assertion
+   (e.g. DOM attribute value, computed CSS, URL, page title). Throw to fail, return to pass:
+      Example: () => {
+        const items = document.querySelectorAll('.todo-item');
+        if (items.length !== 3) throw new Error('Expected 3 todo items, found ' + items.length);
+        return items.length;
+      }
+
+   C) Use browser_run_code_unsafe for Playwright-level assertions (page URL, network state,
+      locator assertions) OR when a step requires SOFT ASSERTIONS — checking multiple conditions
+      and reporting all failures together instead of stopping at the first:
+      Example (soft assertions):
+      async (page) => {
+        const failures = [];
+        if (!await page.getByText('Order Complete').isVisible())
+          failures.push('"Order Complete" not visible');
+        if (!await page.getByRole('button', { name: 'Download' }).isEnabled())
+          failures.push('"Download" button not enabled');
+        if (failures.length) throw new Error('Assertion failures:\n' + failures.join('\n'));
+        return 'All checks passed';
+      }
+      Use soft assertions when the test scenario needs to verify multiple independent
+      conditions and report ALL failures at once (e.g. validating a results page has
+      correct status, correct count, and correct items).
+
+   HARD vs SOFT decision:
+   - Hard (stop on first failure): use verify tools or browser_evaluate for a single critical
+     condition where the rest of the test is meaningless if it fails.
+   - Soft (collect all): use browser_run_code_unsafe with the failures[] pattern when multiple
+     independent conditions should all be checked and reported together.
+
+   ON ANY ASSERTION FAILURE (hard or soft): write a concise failure report (what was expected
+   vs. what was actually found), then stop. Do NOT call any more tools.
 5. The test will FAIL if you respond without calling a Playwright tool.`;
 
         // Combine prompt and system prompt
@@ -59,7 +112,16 @@ export class Orchestrator {
 
         // 1. Setup MCP Server (in-memory, tied to the Playwright test context)
         const mcpServer = await createConnection(
-            { capabilities: ['core', 'testing'] },
+            {
+                capabilities: ['core', 'testing'],
+                // Write console/network/snapshot logs to .playwright-mcp/ files instead of
+                // stdout. The response includes a [Snapshot](path.yml) link the agent can read
+                // for element refs, keeping the full YAML tree out of the context window.
+                outputMode: 'file',
+                // Persist the MCP session state to .playwright-mcp/ so it can be resumed
+                // across steps without re-establishing browser context from scratch.
+                saveSession: true,
+            },
             () => Promise.resolve(contextWithManagedLifecycle)
         );
 
@@ -119,6 +181,8 @@ socket.on('error', () => process.exit(1));
             const fullOutput = [];
             let currentSessionId = existingSessionId;
             let lastToolName = '';
+            let assertionFailed = false;
+            let assertionError = '';
 
             // Spawn the subprocess using the shell so that the CLI args parse properly
             const child = spawn(command, {
@@ -139,12 +203,12 @@ socket.on('error', () => process.exit(1));
                 const chunk = data.toString('utf-8');
                 fullOutput.push(chunk);
                 buffer += chunk;
-                
+
                 let newlineIndex;
                 while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
                     const line = buffer.slice(0, newlineIndex).trim();
                     buffer = buffer.slice(newlineIndex + 1);
-                    
+
                     if (line) {
                         const events = provider.parseStreamLine(line);
                         for (const event of events) {
@@ -163,10 +227,11 @@ socket.on('error', () => process.exit(1));
                             } else if (event.type === 'tool_error') {
                                 if (this.verbose) this.logger.log(`❌ Tool Error: ${event.error}`);
                                 if (lastToolName.includes('browser_verify_')) {
-                                    // Assertion tool failed → definitive test failure
-                                    const err = new Error(`Assertion failed: ${event.error}`);
-                                    child.kill();
-                                    reject(err);
+                                    // Assertion tool failed — flag it but do NOT kill the subprocess.
+                                    // The PostToolUseFailure hook blocks further tool calls and instructs
+                                    // Claude to write a failure summary before stopping gracefully.
+                                    assertionFailed = true;
+                                    assertionError = event.error;
                                 }
                                 // Action tool failed → log but let Claude retry with a different approach
                             } else if (event.type === 'result') {
@@ -183,11 +248,18 @@ socket.on('error', () => process.exit(1));
                 try {
                     await mcpServer.close();
                     tcpServer.close();
-                    await fs.unlink(bridgeScriptPath).catch(() => {});
-                    await fs.unlink(mcpConfigPath).catch(() => {});
-                    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+                    await fs.unlink(bridgeScriptPath).catch(() => { });
+                    await fs.unlink(mcpConfigPath).catch(() => { });
+                    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => { });
                 } catch (e) {
                     // Ignore
+                }
+
+                if (assertionFailed) {
+                    // Prefer Claude's own summary (written after the PostToolUseFailure hook fired)
+                    // over the raw tool error string
+                    const summary = finalResult.trim() || assertionError;
+                    return reject(new Error(summary));
                 }
 
                 if (code !== 0) {

--- a/src/agent/providers/claudeCode.js
+++ b/src/agent/providers/claudeCode.js
@@ -21,7 +21,7 @@ const extractErrorMessage = (obj) => {
   return undefined;
 };
 
-const parseStreamJsonLine = (line) => {
+const parseStreamJsonLine = (line, toolNameById) => {
   if (!line.startsWith("{")) return [];
   try {
     const obj = JSON.parse(line);
@@ -40,11 +40,11 @@ const parseStreamJsonLine = (line) => {
             events.push({ type: "text", text: texts.join("") });
             texts.length = 0;
           }
-          
-          // In Sandcastle they only exposed certain tools. 
-          // For Playwright MCP, we log the tool and its stringified args.
+
+          // Buffer id→name so tool_error events can carry the tool name
+          if (block.id) toolNameById.set(block.id, block.name);
+
           const argsString = typeof block.input === 'object' ? JSON.stringify(block.input) : block.input;
-          
           events.push({
             type: "tool_call",
             name: block.name,
@@ -66,14 +66,15 @@ const parseStreamJsonLine = (line) => {
               : Array.isArray(block.content)
                   ? block.content.map(c => c.text || JSON.stringify(c)).join('\\n')
                   : 'Unknown tool error';
-          
+
           // Clean up section headers (### Error, ### Result) that MCP prepends
           errorText = errorText.replace(/^### (?:Error|Result)\\n/, '').trim();
-          
-          events.push({ 
-            type: "tool_error", 
-            error: errorText, 
-            toolId: block.tool_use_id 
+
+          events.push({
+            type: "tool_error",
+            toolName: toolNameById.get(block.tool_use_id) || '',
+            error: errorText,
+            toolId: block.tool_use_id,
           });
         }
       }
@@ -95,53 +96,57 @@ const parseStreamJsonLine = (line) => {
   return [];
 };
 
-export const claudeCode = (model = "claude-haiku-4-5", options = {}) => ({
-  name: "claude-code",
-  env: options.env ?? {},
-  captureSessions: options.captureSessions ?? true,
+export const claudeCode = (model = "claude-haiku-4-5", options = {}) => {
+  const toolNameById = new Map();
 
-  buildPrintCommand({ prompt, mcpConfigPath, dangerouslySkipPermissions, resumeSession }) {
-    const skipPerms = dangerouslySkipPermissions
-      ? " --dangerously-skip-permissions"
-      : "";
-    const mcpFlag = mcpConfigPath ? ` --mcp-config ${shellEscape(mcpConfigPath)} --strict-mcp-config` : "";
-    const resumeFlag = resumeSession ? ` --resume ${shellEscape(resumeSession)}` : "";
-    return {
-      command: `npx @anthropic-ai/claude-code --print --verbose${skipPerms}${mcpFlag} --output-format stream-json --model ${shellEscape(model)}${resumeFlag} -p -`,
-      stdin: prompt,
-    };
-  },
+  return {
+    name: "claude-code",
+    env: options.env ?? {},
+    captureSessions: options.captureSessions ?? true,
 
-  parseStreamLine(line) {
-    return parseStreamJsonLine(line);
-  },
+    buildPrintCommand({ prompt, mcpConfigPath, dangerouslySkipPermissions, resumeSession }) {
+      const skipPerms = dangerouslySkipPermissions
+        ? " --dangerously-skip-permissions"
+        : "";
+      const mcpFlag = mcpConfigPath ? ` --mcp-config ${shellEscape(mcpConfigPath)} --strict-mcp-config` : "";
+      const resumeFlag = resumeSession ? ` --resume ${shellEscape(resumeSession)}` : "";
+      return {
+        command: `npx @anthropic-ai/claude-code --print --verbose${skipPerms}${mcpFlag} --output-format stream-json --model ${shellEscape(model)}${resumeFlag} -p -`,
+        stdin: prompt,
+      };
+    },
 
-  parseSessionUsage(content) {
-    const lines = content.split("\n");
-    for (let i = lines.length - 1; i >= 0; i--) {
-      const line = lines[i];
-      if (!line) continue;
-      if (!line.startsWith("{")) continue;
-      try {
-        const obj = JSON.parse(line);
-        if (obj.type === "assistant" && obj.message?.usage) {
-          const u = obj.message.usage;
-          if (
-            typeof u.input_tokens === "number" &&
-            typeof u.output_tokens === "number"
-          ) {
-            return {
-              inputTokens: u.input_tokens,
-              cacheCreationInputTokens: u.cache_creation_input_tokens || 0,
-              cacheReadInputTokens: u.cache_read_input_tokens || 0,
-              outputTokens: u.output_tokens,
-            };
+    parseStreamLine(line) {
+      return parseStreamJsonLine(line, toolNameById);
+    },
+
+    parseSessionUsage(content) {
+      const lines = content.split("\n");
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i];
+        if (!line) continue;
+        if (!line.startsWith("{")) continue;
+        try {
+          const obj = JSON.parse(line);
+          if (obj.type === "assistant" && obj.message?.usage) {
+            const u = obj.message.usage;
+            if (
+              typeof u.input_tokens === "number" &&
+              typeof u.output_tokens === "number"
+            ) {
+              return {
+                inputTokens: u.input_tokens,
+                cacheCreationInputTokens: u.cache_creation_input_tokens || 0,
+                cacheReadInputTokens: u.cache_read_input_tokens || 0,
+                outputTokens: u.output_tokens,
+              };
+            }
           }
+        } catch {
+          // Not valid JSON — skip
         }
-      } catch {
-        // Not valid JSON — skip
       }
-    }
-    return undefined;
-  },
-});
+      return undefined;
+    },
+  };
+};

--- a/src/cli/init.js
+++ b/src/cli/init.js
@@ -14,6 +14,36 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+const CLAUDE_HOOKS_SETTINGS = {
+  hooks: {
+    PostToolUseFailure: [
+      {
+        matcher: 'browser_verify_',
+        hooks: [
+          {
+            type: 'prompt',
+            prompt: 'A Playwright assertion tool just failed. Hook input:\n$ARGUMENTS\n\nThis is a definitive test failure — the browser verification confirmed the expected condition was NOT met.\n\nReturn this JSON:\n{"decision": "block", "reason": "Assertion failed", "hookSpecificOutput": {"hookEventName": "PostToolUseFailure", "additionalContext": "ASSERTION FAILED. Do NOT call any more browser tools. Write a clear 1-2 sentence failure summary explaining what was expected vs what was actually found on the page, then stop."}}',
+            model: 'claude-haiku-4-5',
+            timeout: 30,
+          },
+        ],
+      },
+    ],
+    Stop: [
+      {
+        hooks: [
+          {
+            type: 'prompt',
+            prompt: 'You are validating a Playwright test agent\'s final output. Hook context:\n$ARGUMENTS\n\nCheck the tool_calls array. If none of them are browser_verify_* tools, return {"ok": true} immediately — no assertion was involved.\n\nIf there were browser_verify_* tool calls, inspect the output field. Does it contain a clear failure summary stating what was expected and what was actually found on the page? If yes: {"ok": true}. If the output is absent or too vague: {"ok": false, "reason": "Please write a clear 1-2 sentence failure summary: what the test expected to see, and what was actually on the page."}',
+            model: 'claude-haiku-4-5',
+            timeout: 30,
+          },
+        ],
+      },
+    ],
+  },
+};
+
 // Read CLI's own package.json to detect version
 const cliPackageJson = JSON.parse(
   readFileSync(join(__dirname, '../../package.json'), 'utf-8')
@@ -119,6 +149,12 @@ export async function init(cliFramework, options) {
   const templateDir = join(__dirname, 'templates', framework);
 
   try {
+    // Write Claude Code hooks settings — enables PostToolUseFailure and Stop hooks
+    // that replace the hard-coded kill logic and provide meaningful failure reports
+    const claudeDir = join(targetDir, '.claude');
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(join(claudeDir, 'settings.json'), JSON.stringify(CLAUDE_HOOKS_SETTINGS, null, 2));
+
     const toCopy = ['gitignore', 'package.json', 'README.md', '.env.example'];
     
     if (framework === 'playwright-bdd') {

--- a/src/cli/templates/cucumber/README.md
+++ b/src/cli/templates/cucumber/README.md
@@ -46,5 +46,5 @@ Browser setup and teardown is handled automatically.
 
 ## Learn More
 
-- [OpenQA Documentation](https://www.auto-browse.com/)
+- [OpenQA Documentation](https://openqa.io/)
 - [Cucumber.js Documentation](https://github.com/cucumber/cucumber-js)

--- a/src/cli/templates/playwright-bdd/README.md
+++ b/src/cli/templates/playwright-bdd/README.md
@@ -47,5 +47,5 @@ The AI agent automatically handles all steps - no code required!
 
 ## Learn More
 
-- [OpenQA Documentation](https://www.auto-browse.com/)
+- [OpenQA Documentation](https://openqa.io/)
 - [Playwright-BDD Documentation](https://vitalets.github.io/playwright-bdd/)

--- a/src/cli/templates/playwright-yaml/README.md
+++ b/src/cli/templates/playwright-yaml/README.md
@@ -113,5 +113,5 @@ cp .env.example .env
 
 ## Learn More
 
-- [OpenQA Documentation](https://github.com/auto-browse/openqa)
+- [OpenQA Documentation](https://openqa.io/)
 - [Playwright Documentation](https://playwright.dev)


### PR DESCRIPTION
## Summary

- **Graceful assertion failure**: Replace `child.kill()` with `assertionFailed` flag; `PostToolUseFailure` hook blocks further tool calls and prompts Claude to write a failure summary before exiting naturally — no more abruptly killed processes
- **Hooks scaffolded via `openqa init`**: `PostToolUseFailure` + `Stop` hooks written to `.openqa/.claude/settings.json` during project setup
- **MCP token optimization**: `outputMode: 'file'` writes console/network/snapshot logs to `.playwright-mcp/` files; agent reuses `[Snapshot](path.yml)` links from action responses instead of always calling `browser_snapshot` explicitly
- **Cleaner provider abstraction**: `tool_error` events now carry `toolName` (correlated from `tool_use_id`), removing cross-event `lastToolName` state from the Orchestrator
- **Better assertion guidance**: Rule 4 now requires built-in verify tools first; count assertions use `browser_verify_list_visible` with item names instead of DOM query code
- **URL updates**: All `auto-browse.com` / `auto-browse/openqa` references updated to `openqa.io` / `openqa-labs/openqa`
- **Version**: 0.0.6 → 0.0.7

## Test plan

- [ ] Run `examples/playwright-bdd` — passing scenarios pass, intentionally failing scenario stops early with Claude's failure summary
- [ ] Verify `browser_verify_list_visible` is used for count assertions (not `browser_evaluate`)
- [ ] Verify snapshot reuse — action responses include `[Snapshot](...)` link, no redundant `browser_snapshot` calls
- [ ] Run `openqa init` — confirm `.openqa/.claude/settings.json` is generated with hooks

🤖 Generated with [Claude Code](https://claude.ai/claude-code)