### PR TITLE
fix: move AI provider SDKs to regular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "openqa",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openqa",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": ">=0.2",
         "@clack/prompts": "^1.3.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@opencode-ai/sdk": ">=1.14",
         "@playwright/mcp": "^0.0.73",
         "chalk": "^5.6.2",
         "commander": "^12.1.0",
@@ -32,20 +34,12 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@anthropic-ai/claude-agent-sdk": ">=0.2",
         "@cucumber/cucumber": "^11.0.0",
-        "@opencode-ai/sdk": ">=1.14",
         "@playwright/test": "^1.57.0",
         "playwright-bdd": "^8.0.0"
       },
       "peerDependenciesMeta": {
-        "@anthropic-ai/claude-agent-sdk": {
-          "optional": true
-        },
         "@cucumber/cucumber": {
-          "optional": true
-        },
-        "@opencode-ai/sdk": {
           "optional": true
         },
         "playwright-bdd": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openqa",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Agent Harness for Browser Test Automation — write tests in natural language, powered by Claude Code or OpenCode",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -42,8 +42,10 @@
     "access": "public"
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": ">=0.2",
     "@clack/prompts": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@opencode-ai/sdk": ">=1.14",
     "@playwright/mcp": "^0.0.73",
     "chalk": "^5.6.2",
     "commander": "^12.1.0",
@@ -52,19 +54,11 @@
     "js-yaml": "^4.1.1"
   },
   "peerDependencies": {
-    "@anthropic-ai/claude-agent-sdk": ">=0.2",
     "@cucumber/cucumber": "^11.0.0",
-    "@opencode-ai/sdk": ">=1.14",
     "@playwright/test": "^1.57.0",
     "playwright-bdd": "^8.0.0"
   },
   "peerDependenciesMeta": {
-    "@anthropic-ai/claude-agent-sdk": {
-      "optional": true
-    },
-    "@opencode-ai/sdk": {
-      "optional": true
-    },
     "playwright-bdd": {
       "optional": true
     },

--- a/src/cli/init.js
+++ b/src/cli/init.js
@@ -24,7 +24,7 @@ const FRAMEWORKS = {
   'playwright-bdd': {
     name: 'Playwright-BDD',
     description: 'Playwright with Gherkin/Cucumber syntax',
-    dependencies: ['openqa', 'playwright-bdd', '@playwright/test', 'typescript'],
+    dependencies: ['openqa', 'playwright-bdd', '@playwright/test', 'typescript', 'dotenv'],
     devDependencies: ['@cucumber/cucumber'],
   },
   'cucumber': {

--- a/src/cli/templates/cucumber/.env.example
+++ b/src/cli/templates/cucumber/.env.example
@@ -1,32 +1,29 @@
 # ============================================
 # OpenQA Environment Configuration
 # ============================================
+# Copy this file to .env and fill in the values you need.
+# Variables here are loaded automatically when tests run.
 
-# --------------------------------------------
-# Option 1: Claude Code Agent (Recommended)
-# --------------------------------------------
-# Choose ONE of the following methods:
+# --- Application Under Test ---
+# BASE_URL=https://your-app.com         # Sets the default baseURL in playwright.config
+                                        # Use this to switch between dev/staging/prod
 
-# A. Claude Code CLI login (recommended)
-#    Run: claude login
-#    No env vars needed!
+# --- App Credentials ---
+# APP_USERNAME=your_username            # Available as process.env.APP_USERNAME in steps
+# APP_PASSWORD=your_password            # Available as process.env.APP_PASSWORD in steps
 
-# B. Anthropic API Key
-#    Get your key from: https://console.anthropic.com/
-# ANTHROPIC_API_KEY=your_api_key_here
+# --- Agent Verbosity ---
+# OPENQA_VERBOSE=false                  # Set to false to suppress agent step logs (default: true)
 
-# C. Claude Code OAuth Token
-# CLAUDE_CODE_OAUTH_TOKEN=your_oauth_token_here
+# --- Headless Mode ---
+# HEADLESS=false                        # Set to false to watch the browser (default: true)
 
-# --------------------------------------------
-# Option 2: Other AI Providers
-# --------------------------------------------
-# Uncomment and configure if using OpenAI, Google, etc.
+# --- Authentication ---
+# For local development, just log in once — no keys needed:
+#   Claude Code:  claude login
+#   OpenCode:     opencode auth login   (GitLab Duo, GitHub Copilot, Anthropic, OpenAI, Google)
 
-# AGENT_TYPE=langchain
-# DEFAULT_PROVIDER=openai          # or 'google', 'anthropic'
-# OPENAI_API_KEY=your_key          # or GOOGLE_API_KEY, ANTHROPIC_API_KEY
-
-# Optional customization
-# OPENAI_MODEL=gpt-4o              # or GOOGLE_MODEL, ANTHROPIC_MODEL
-# RECURSION_LIMIT=100              # default: 100
+# For CI or explicit API key usage, uncomment the relevant line:
+# ANTHROPIC_API_KEY=your_key_here
+# OPENAI_API_KEY=your_key_here
+# GOOGLE_API_KEY=your_key_here

--- a/src/cli/templates/cucumber/features/step_definitions/steps.js
+++ b/src/cli/templates/cucumber/features/step_definitions/steps.js
@@ -10,6 +10,15 @@ let page;
 
 const verbose = process.env.OPENQA_VERBOSE !== 'false';
 
+// Build context header from env vars so the agent knows the app URL and credentials
+function buildEnvContext() {
+    const lines = [];
+    if (process.env.BASE_URL)     lines.push(`Application base URL: ${process.env.BASE_URL}`);
+    if (process.env.APP_USERNAME) lines.push(`App username: ${process.env.APP_USERNAME}`);
+    if (process.env.APP_PASSWORD) lines.push(`App password: ${process.env.APP_PASSWORD}`);
+    return lines.length > 0 ? `[Context]\n${lines.join('\n')}\n\n` : '';
+}
+
 Before(async function () {
   const headless = process.env.HEADLESS !== 'false';
   browser = await chromium.launch({ headless });
@@ -25,5 +34,5 @@ After(async function () {
 
 // Generic AI step - handles ALL Given/When/Then steps with natural language
 defineStep(/^(.*)$/, async function (action) {
-  await runAgent(claudeCode('claude-haiku-4-5'), action, context, { verbose });
+  await runAgent(claudeCode('claude-haiku-4-5'), `${buildEnvContext()}${action}`, context, { verbose });
 });

--- a/src/cli/templates/cucumber/features/step_definitions/steps.js
+++ b/src/cli/templates/cucumber/features/step_definitions/steps.js
@@ -1,12 +1,14 @@
 import { Before, After, defineStep, setDefaultTimeout } from '@cucumber/cucumber';
-import { chromium, Browser, BrowserContext, Page } from '@playwright/test';
+import { chromium } from '@playwright/test';
 import { runAgent, claudeCode } from 'openqa';
 
 setDefaultTimeout(240000); // 4 minutes
 
-let browser: Browser;
-let context: BrowserContext;
-let page: Page;
+let browser;
+let context;
+let page;
+
+const verbose = process.env.OPENQA_VERBOSE !== 'false';
 
 Before(async function () {
   const headless = process.env.HEADLESS !== 'false';
@@ -23,5 +25,5 @@ After(async function () {
 
 // Generic AI step - handles ALL Given/When/Then steps with natural language
 defineStep(/^(.*)$/, async function (action) {
-  await runAgent(claudeCode('claude-haiku-4-5'), action, context, { verbose: true });
+  await runAgent(claudeCode('claude-haiku-4-5'), action, context, { verbose });
 });

--- a/src/cli/templates/playwright-bdd/.env.example
+++ b/src/cli/templates/playwright-bdd/.env.example
@@ -1,32 +1,29 @@
 # ============================================
 # OpenQA Environment Configuration
 # ============================================
+# Copy this file to .env and fill in the values you need.
+# Variables here are loaded automatically when tests run.
 
-# --------------------------------------------
-# Option 1: Claude Code Agent (Recommended)
-# --------------------------------------------
-# Choose ONE of the following methods:
+# --- Application Under Test ---
+# BASE_URL=https://your-app.com         # Sets the default baseURL in playwright.config
+                                        # Use this to switch between dev/staging/prod
 
-# A. Claude Code CLI login (recommended)
-#    Run: claude login
-#    No env vars needed!
+# --- App Credentials ---
+# APP_USERNAME=your_username            # Available as process.env.APP_USERNAME in steps
+# APP_PASSWORD=your_password            # Available as process.env.APP_PASSWORD in steps
 
-# B. Anthropic API Key
-#    Get your key from: https://console.anthropic.com/
-# ANTHROPIC_API_KEY=your_api_key_here
+# --- Agent Verbosity ---
+# OPENQA_VERBOSE=false                  # Set to false to suppress agent step logs (default: true)
 
-# C. Claude Code OAuth Token
-# CLAUDE_CODE_OAUTH_TOKEN=your_oauth_token_here
+# --- Headless Mode ---
+# HEADLESS=false                        # Set to false to watch the browser (default: true)
 
-# --------------------------------------------
-# Option 2: Other AI Providers
-# --------------------------------------------
-# Uncomment and configure if using OpenAI, Google, etc.
+# --- Authentication ---
+# For local development, just log in once — no keys needed:
+#   Claude Code:  claude login
+#   OpenCode:     opencode auth login   (GitLab Duo, GitHub Copilot, Anthropic, OpenAI, Google)
 
-# AGENT_TYPE=langchain
-# DEFAULT_PROVIDER=openai          # or 'google', 'anthropic'
-# OPENAI_API_KEY=your_key          # or GOOGLE_API_KEY, ANTHROPIC_API_KEY
-
-# Optional customization
-# OPENAI_MODEL=gpt-4o              # or GOOGLE_MODEL, ANTHROPIC_MODEL
-# RECURSION_LIMIT=100              # default: 100
+# For CI or explicit API key usage, uncomment the relevant line:
+# ANTHROPIC_API_KEY=your_key_here
+# OPENAI_API_KEY=your_key_here
+# GOOGLE_API_KEY=your_key_here

--- a/src/cli/templates/playwright-bdd/features/steps/steps.ts
+++ b/src/cli/templates/playwright-bdd/features/steps/steps.ts
@@ -3,7 +3,16 @@ import { aistep } from './fixtures';
 
 const verbose = process.env.OPENQA_VERBOSE !== 'false';
 
+// Build context header from env vars so the agent knows the app URL and credentials
+function buildEnvContext(): string {
+    const lines: string[] = [];
+    if (process.env.BASE_URL)     lines.push(`Application base URL: ${process.env.BASE_URL}`);
+    if (process.env.APP_USERNAME) lines.push(`App username: ${process.env.APP_USERNAME}`);
+    if (process.env.APP_PASSWORD) lines.push(`App password: ${process.env.APP_PASSWORD}`);
+    return lines.length > 0 ? `[Context]\n${lines.join('\n')}\n\n` : '';
+}
+
 // Generic AI step - handles ALL Given/When/Then steps with natural language
 aistep(/^(.*)$/, async ({ page }, action: string) => {
-    await runAgent(claudeCode('claude-haiku-4-5'), action, page, { verbose });
+    await runAgent(claudeCode('claude-haiku-4-5'), `${buildEnvContext()}${action}`, page, { verbose });
 });

--- a/src/cli/templates/playwright-bdd/features/steps/steps.ts
+++ b/src/cli/templates/playwright-bdd/features/steps/steps.ts
@@ -1,8 +1,9 @@
 import { runAgent, claudeCode } from 'openqa';
 import { aistep } from './fixtures';
 
+const verbose = process.env.OPENQA_VERBOSE !== 'false';
+
 // Generic AI step - handles ALL Given/When/Then steps with natural language
-aistep(/^(.*)$/, async ({ page, context }, action: string) => {
-    console.log(`Executing AI step: ${action}`);
-    await runAgent(claudeCode('claude-haiku-4-5'), action, page, { verbose: true });
+aistep(/^(.*)$/, async ({ page }, action: string) => {
+    await runAgent(claudeCode('claude-haiku-4-5'), action, page, { verbose });
 });

--- a/src/cli/templates/playwright-bdd/package.json
+++ b/src/cli/templates/playwright-bdd/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@cucumber/cucumber": "^11.0.1",
     "@playwright/test": "^1.57.0",
+    "dotenv": "^16.0.0",
     "openqa": "latest",
     "playwright-bdd": "^8.4.1",
     "typescript": "^5.7.2"

--- a/src/cli/templates/playwright-bdd/playwright.config.ts
+++ b/src/cli/templates/playwright-bdd/playwright.config.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { defineConfig } from '@playwright/test';
 import { defineBddConfig } from 'playwright-bdd';
 
@@ -12,10 +13,11 @@ export default defineConfig({
   fullyParallel: true,
   reporter: [['html', { open: 'never' }]],
   use: {
+    headless: process.env.HEADLESS !== 'false',
+    baseURL: process.env.BASE_URL,
     screenshot: 'on',
     trace: 'on',
     video: 'on',
-    headless: true,
   },
   projects: [
     {

--- a/src/cli/templates/playwright-yaml/.env.example
+++ b/src/cli/templates/playwright-yaml/.env.example
@@ -1,32 +1,29 @@
 # ============================================
 # OpenQA Environment Configuration
 # ============================================
+# Copy this file to .env and fill in the values you need.
+# Variables here are loaded automatically when tests run.
 
-# --------------------------------------------
-# Option 1: Claude Code Agent (Recommended)
-# --------------------------------------------
-# Choose ONE of the following methods:
+# --- Application Under Test ---
+# BASE_URL=https://your-app.com         # Sets the default baseURL in playwright.config
+                                        # Use this to switch between dev/staging/prod
 
-# A. Claude Code CLI login (recommended)
-#    Run: claude login
-#    No env vars needed!
+# --- App Credentials ---
+# APP_USERNAME=your_username            # Available as process.env.APP_USERNAME in steps
+# APP_PASSWORD=your_password            # Available as process.env.APP_PASSWORD in steps
 
-# B. Anthropic API Key
-#    Get your key from: https://console.anthropic.com/
-# ANTHROPIC_API_KEY=your_api_key_here
+# --- Agent Verbosity ---
+# OPENQA_VERBOSE=false                  # Set to false to suppress agent step logs (default: true)
 
-# C. Claude Code OAuth Token
-# CLAUDE_CODE_OAUTH_TOKEN=your_oauth_token_here
+# --- Headless Mode ---
+# HEADLESS=false                        # Set to false to watch the browser (default: true)
 
-# --------------------------------------------
-# Option 2: Other AI Providers
-# --------------------------------------------
-# Uncomment and configure if using OpenAI, Google, etc.
+# --- Authentication ---
+# For local development, just log in once — no keys needed:
+#   Claude Code:  claude login
+#   OpenCode:     opencode auth login   (GitLab Duo, GitHub Copilot, Anthropic, OpenAI, Google)
 
-# AGENT_TYPE=langchain
-# DEFAULT_PROVIDER=openai          # or 'google', 'anthropic'
-# OPENAI_API_KEY=your_key          # or GOOGLE_API_KEY, ANTHROPIC_API_KEY
-
-# Optional customization
-# OPENAI_MODEL=gpt-4o              # or GOOGLE_MODEL, ANTHROPIC_MODEL
-# RECURSION_LIMIT=100              # default: 100
+# For CI or explicit API key usage, uncomment the relevant line:
+# ANTHROPIC_API_KEY=your_key_here
+# OPENAI_API_KEY=your_key_here
+# GOOGLE_API_KEY=your_key_here

--- a/src/cli/templates/playwright-yaml/package.json
+++ b/src/cli/templates/playwright-yaml/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",
+    "dotenv": "^16.0.0",
     "openqa": "latest"
   }
 }

--- a/src/cli/templates/playwright-yaml/playwright.config.js
+++ b/src/cli/templates/playwright-yaml/playwright.config.js
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
@@ -10,7 +11,7 @@ export default defineConfig({
     ['html', { open: 'never', outputFolder: 'playwright-report' }],
   ],
   use: {
-    baseURL: 'https://demo.playwright.dev/todomvc/',
+    baseURL: process.env.BASE_URL,
     screenshot: 'on',
     trace: 'on',
     video: 'on',


### PR DESCRIPTION
## Problem

Both `@anthropic-ai/claude-agent-sdk` and `@opencode-ai/sdk` were marked as optional peer dependencies. Users who installed `openqa` directly (without going through `npx openqa init`) got a crash:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@opencode-ai/sdk'
```

This happened even when only importing `claudeCode` — static top-level imports mean Node resolves both SDKs at module load time regardless of which provider is used.

## Fix

Move both SDKs to regular `dependencies`. They're only consumed by openqa — users would never install them independently — so there's no reason to make them optional.

`@playwright/test`, `playwright-bdd`, and `@cucumber/cucumber` remain as peer deps since those are owned and versioned by the user's project.

Closes #16